### PR TITLE
Remove all upper bounds, bump to 0.4

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,19 @@
+{ cabal, bifunctors, mtl, profunctors, semigroupoids, semigroups
+, transformers, vector
+}:
+
+cabal.mkDerivation (self: {
+  pname = "these";
+  version = "0.4.1";
+  sha256 = "135qiyg87cf9rl10zb681mwnrwxdm37h76dnlia8amkkmpkg4wia";
+  buildDepends = [
+    bifunctors mtl profunctors semigroupoids semigroups transformers
+    vector
+  ];
+  meta = {
+    homepage = "https://github.com/isomorphism/these";
+    description = "An either-or-both data type, with corresponding hybrid error/writer monad transformer";
+    license = self.stdenv.lib.licenses.bsd3;
+    platforms = self.ghc.meta.platforms;
+  };
+})

--- a/these.cabal
+++ b/these.cabal
@@ -1,5 +1,5 @@
 Name:                these
-Version:             0.3
+Version:             0.4
 Synopsis:            An either-or-both data type, with corresponding hybrid error/writer monad transformer.
 Homepage:            https://github.com/isomorphism/these
 License:             BSD3
@@ -17,12 +17,12 @@ Library
                        Control.Monad.Chronicle.Class, 
                        Control.Monad.Trans.Chronicle
   Build-depends:       base          >= 3   && < 5,
-                       containers    >= 0.4 && < 1.0,
-                       mtl           >= 2   && < 3,
-                       transformers  >= 0.2 && < 1.0,
-                       semigroups    >= 0.8 && < 1.0,
-                       bifunctors    >= 0.1 && < 4.0,
-                       semigroupoids >= 1.0 && < 4.0,
-                       profunctors   >= 3   && < 4,
-                       vector        >= 0.4 && < 1.0
+                       containers    >= 0.4,
+                       mtl           >= 2,
+                       transformers  >= 0.2,
+                       semigroups    >= 0.8,
+                       bifunctors    >= 0.1,
+                       semigroupoids >= 1.0,
+                       profunctors   >= 3,
+                       vector        >= 0.4
 

--- a/these.cabal
+++ b/these.cabal
@@ -1,5 +1,5 @@
 Name:                these
-Version:             0.4
+Version:             0.4.2
 Synopsis:            An either-or-both data type, with corresponding hybrid error/writer monad transformer.
 Homepage:            https://github.com/isomorphism/these
 License:             BSD3
@@ -17,12 +17,12 @@ Library
                        Control.Monad.Chronicle.Class, 
                        Control.Monad.Trans.Chronicle
   Build-depends:       base          >= 3   && < 5,
-                       containers    >= 0.4,
-                       mtl           >= 2,
-                       transformers  >= 0.2,
-                       semigroups    >= 0.8,
-                       bifunctors    >= 0.1,
-                       semigroupoids >= 1.0,
-                       profunctors   >= 3,
-                       vector        >= 0.4
+                       containers    >= 0.4 && < 0.6,
+                       mtl           >= 2   && < 2.2,
+                       transformers  >= 0.2 && < 0.4,
+                       semigroups    >= 0.8 && < 0.14,
+                       bifunctors    >= 0.1 && < 4.2,
+                       semigroupoids >= 1.0 && < 4.1,
+                       profunctors   >= 3   && < 4.1,
+                       vector        >= 0.4 && < 0.11
 


### PR DESCRIPTION
The upper bounds are getting in the way of building with modern versions of many packages.  I've removed them and confirmed it still builds against the current Haskell Platform with GHC 7.6.3.  Can you please upload the update?  Hackage 2 denies me access to updating this package, since my e-mail address (`johnw@newartisans.com`) is not listed as the current maintainer.  Thanks!