### PR TITLE
Add ExceptT instance using transformers-compat

### DIFF
--- a/Control/Monad/Chronicle/Class.hs
+++ b/Control/Monad/Chronicle/Class.hs
@@ -25,6 +25,7 @@ import qualified Control.Monad.Trans.Chronicle as Ch
 import Control.Monad.Trans.Identity as Identity
 import Control.Monad.Trans.Maybe as Maybe
 import Control.Monad.Trans.Error as Error
+import Control.Monad.Trans.Except as Except
 import Control.Monad.Trans.Reader as Reader
 import Control.Monad.Trans.RWS.Lazy as LazyRWS
 import Control.Monad.Trans.RWS.Strict as StrictRWS
@@ -129,6 +130,15 @@ instance (Error e, MonadChronicle c m) => MonadChronicle c (ErrorT e m) where
     absolve x (ErrorT m) = ErrorT $ absolve (Right x) m
     condemn (ErrorT m) = ErrorT $ condemn m
     retcon f (ErrorT m) = ErrorT $ retcon f m
+    chronicle = lift . chronicle
+
+instance (MonadChronicle c m) => MonadChronicle c (ExceptT e m) where
+    dictate = lift . dictate
+    confess = lift . confess
+    memento (ExceptT m) = ExceptT $ either (Right . Left) (Right <$>) `liftM` memento m
+    absolve x (ExceptT m) = ExceptT $ absolve (Right x) m
+    condemn (ExceptT m) = ExceptT $ condemn m
+    retcon f (ExceptT m) = ExceptT $ retcon f m
     chronicle = lift . chronicle
 
 instance (MonadChronicle c m) => MonadChronicle c (ReaderT r m) where

--- a/these.cabal
+++ b/these.cabal
@@ -16,15 +16,16 @@ Library
                        Control.Monad.Chronicle,
                        Control.Monad.Chronicle.Class,
                        Control.Monad.Trans.Chronicle
-  Build-depends:       base          >= 3   && < 5,
-                       containers    >= 0.4 && < 0.6,
-                       mtl           >= 2   && < 2.3,
-                       transformers  >= 0.2 && < 0.5,
-                       semigroups    >= 0.8 && < 0.17,
-                       bifunctors    >= 0.1 && < 5.1,
-                       semigroupoids >= 1.0 && < 5.1,
-                       profunctors   >= 3   && < 5.2,
-                       vector        >= 0.4 && < 0.12
+  Build-depends:       base                >= 3   && < 5,
+                       containers          >= 0.4 && < 0.6,
+                       mtl                 >= 2   && < 2.3,
+                       transformers        >= 0.2 && < 0.5,
+                       semigroups          >= 0.8 && < 0.17,
+                       bifunctors          >= 0.1 && < 5.1,
+                       semigroupoids       >= 1.0 && < 5.1,
+                       profunctors         >= 3   && < 5.2,
+                       vector              >= 0.4 && < 0.12,
+                       transformers-compat >= 0.2 && < 0.5
   if impl(ghc <7.5)
     build-depends:     ghc-prim
   ghc-options:         -Wall


### PR DESCRIPTION
This change follows @bergmark's approach discussed here:
https://github.com/fpco/stackage/issues/439

**Background**:
[Control.Monad.Trans.Error](https://hackage.haskell.org/package/transformers-0.4.3.0/docs/Control-Monad-Trans-Error.html) is deprecated and to be replaced by [Control.Monad.Trans.Except](https://hackage.haskell.org/package/transformers-0.4.3.0/docs/Control-Monad-Trans-Except.html).