### PR TITLE
Bump semigroups upper bound to <0.18

### DIFF
--- a/these.cabal
+++ b/these.cabal
@@ -20,7 +20,7 @@ Library
                        containers          >= 0.4 && < 0.6,
                        mtl                 >= 2   && < 2.3,
                        transformers        >= 0.2 && < 0.5,
-                       semigroups          >= 0.8 && < 0.17,
+                       semigroups          >= 0.8 && < 0.18,
                        bifunctors          >= 0.1 && < 5.1,
                        semigroupoids       >= 1.0 && < 5.1,
                        profunctors         >= 3   && < 5.2,


### PR DESCRIPTION
Related https://github.com/fpco/stackage/issues/827