### PR TITLE
Generalizing Applicative/Monad instances to Semigroups instead of Monoids

### DIFF
--- a/Control/Monad/Chronicle/Class.hs
+++ b/Control/Monad/Chronicle/Class.hs
@@ -38,7 +38,7 @@ import Control.Monad.Trans.Writer.Strict as StrictWriter
 import Control.Monad.Trans.Class (lift)
 import Control.Monad (liftM)
 import Data.Default.Class
-import Data.Monoid
+import Data.Semigroup
 import Prelude -- Fix redundant import warnings
 
 
@@ -93,7 +93,7 @@ class (Monad m) => MonadChronicle c m | m -> c where
     chronicle :: These c a -> m a
 
 
-instance (Monoid c) => MonadChronicle c (These c) where
+instance (Semigroup c) => MonadChronicle c (These c) where
     dictate c = These c ()
     confess c = This c
     memento (This c) = That (Left c)
@@ -106,7 +106,7 @@ instance (Monoid c) => MonadChronicle c (These c) where
     retcon = mapThis
     chronicle = id
 
-instance (Monoid c, Monad m) => MonadChronicle c (ChronicleT c m) where
+instance (Semigroup c, Monad m) => MonadChronicle c (ChronicleT c m) where
     dictate = Ch.dictate
     confess = Ch.confess
     memento = Ch.memento

--- a/Control/Monad/Trans/Chronicle.hs
+++ b/Control/Monad/Trans/Chronicle.hs
@@ -30,7 +30,8 @@ import Data.Default.Class
 import Data.Functor.Apply (Apply(..))
 import Data.Functor.Bind (Bind(..))
 import Data.Functor.Identity
-import Data.Monoid
+import Data.Monoid hiding ((<>))
+import Data.Semigroup
 
 import Control.Monad.Error.Class
 import Control.Monad.Reader.Class
@@ -61,17 +62,17 @@ newtype ChronicleT c m a = ChronicleT { runChronicleT :: m (These c a) }
 instance (Functor m) => Functor (ChronicleT c m) where
     fmap f (ChronicleT c) =  ChronicleT (fmap f <$> c)
 
-instance (Monoid c, Apply m) => Apply (ChronicleT c m) where
+instance (Semigroup c, Apply m) => Apply (ChronicleT c m) where
     ChronicleT f <.> ChronicleT x = ChronicleT ((<.>) <$> f <.> x)
 
-instance (Monoid c, Applicative m) => Applicative (ChronicleT c m) where
+instance (Semigroup c, Applicative m) => Applicative (ChronicleT c m) where
     pure = ChronicleT . pure . pure
     ChronicleT f <*> ChronicleT x = ChronicleT (liftA2 (<*>) f x)
 
-instance (Monoid c, Apply m, Monad m) => Bind (ChronicleT c m) where
+instance (Semigroup c, Apply m, Monad m) => Bind (ChronicleT c m) where
     (>>-) = (>>=)
 
-instance (Monoid c, Monad m) => Monad (ChronicleT c m) where
+instance (Semigroup c, Monad m) => Monad (ChronicleT c m) where
     return = ChronicleT . return . return
     m >>= k = ChronicleT $ 
         do cx <- runChronicleT m
@@ -80,22 +81,22 @@ instance (Monoid c, Monad m) => Monad (ChronicleT c m) where
                That    x -> runChronicleT (k x)
                These a x -> do cy <- runChronicleT (k x)
                                return $ case cy of
-                                            This  b   -> This (mappend a b)
+                                            This  b   -> This (a <> b)
                                             That    y -> These a y
-                                            These b y -> These (mappend a b) y
+                                            These b y -> These (a <> b) y
 
-instance (Monoid c) => MonadTrans (ChronicleT c) where
+instance (Semigroup c) => MonadTrans (ChronicleT c) where
     lift m = ChronicleT (That `liftM` m)
 
-instance (Monoid c, MonadIO m) => MonadIO (ChronicleT c m) where
+instance (Semigroup c, MonadIO m) => MonadIO (ChronicleT c m) where
     liftIO = lift . liftIO
 
 
-instance (Monoid c, Applicative m, Monad m) => Alternative (ChronicleT c m) where
+instance (Semigroup c, Monoid c, Applicative m, Monad m) => Alternative (ChronicleT c m) where
     empty = mzero
     (<|>) = mplus
 
-instance (Monoid c, Monad m) => MonadPlus (ChronicleT c m) where
+instance (Semigroup c, Monoid c, Monad m) => MonadPlus (ChronicleT c m) where
     mzero = confess mempty
     mplus x y = do x' <- memento x
                    case x' of
@@ -103,24 +104,24 @@ instance (Monoid c, Monad m) => MonadPlus (ChronicleT c m) where
                        Right r -> return r
 
 
-instance (Monoid c, MonadError e m) => MonadError e (ChronicleT c m) where
+instance (Semigroup c, MonadError e m) => MonadError e (ChronicleT c m) where
     throwError = lift . throwError
     catchError (ChronicleT m) c = ChronicleT $ catchError m (runChronicleT . c)
 
 
-instance (Monoid c, MonadReader r m) => MonadReader r (ChronicleT c m) where
+instance (Semigroup c, MonadReader r m) => MonadReader r (ChronicleT c m) where
     ask = lift ask
     local f (ChronicleT m) = ChronicleT $ local f m
     reader = lift . reader
 
-instance (Monoid c, MonadRWS r w s m) => MonadRWS r w s (ChronicleT c m) where
+instance (Semigroup c, MonadRWS r w s m) => MonadRWS r w s (ChronicleT c m) where
 
-instance (Monoid c, MonadState s m) => MonadState s (ChronicleT c m) where
+instance (Semigroup c, MonadState s m) => MonadState s (ChronicleT c m) where
     get = lift get
     put = lift . put
     state = lift . state
 
-instance (Monoid c, MonadWriter w m) => MonadWriter w (ChronicleT c m) where
+instance (Semigroup c, MonadWriter w m) => MonadWriter w (ChronicleT c m) where
     tell = lift . tell
     listen (ChronicleT m) = ChronicleT $ do
         (m', w) <- listen m
@@ -136,7 +137,7 @@ instance (Monoid c, MonadWriter w m) => MonadWriter w (ChronicleT c m) where
 
 -- this is basically copied from the instance for Either in transformers
 -- need to test this to make sure it's actually sensible...?
-instance (Monoid c, MonadFix m) => MonadFix (ChronicleT c m) where
+instance (Semigroup c, MonadFix m) => MonadFix (ChronicleT c m) where
     mfix f = ChronicleT (mfix (runChronicleT . f . these (const bomb) id (flip const)))
       where bomb = error "mfix (ChronicleT): inner compuation returned This value"
 
@@ -144,7 +145,7 @@ instance (Monoid c, MonadFix m) => MonadFix (ChronicleT c m) where
 -- | @'dictate' c@ is an action that records the output @c@.
 --   
 --   Equivalent to 'tell' for the 'Writer' monad.
-dictate :: (Monoid c, Monad m) => c -> ChronicleT c m ()
+dictate :: (Semigroup c, Monad m) => c -> ChronicleT c m ()
 dictate c = ChronicleT $ return (These c ())
 
 -- | @'disclose' c@ is an action that records the output @c@ and returns a
@@ -153,13 +154,13 @@ dictate c = ChronicleT $ return (These c ())
 --   This is a convenience function for reporting non-fatal errors in one
 --   branch a @case@, or similar scenarios when there is no meaningful 
 --   result but a placeholder of sorts is needed in order to continue.
-disclose :: (Default a, Monoid c, Monad m) => c -> ChronicleT c m a
+disclose :: (Default a, Semigroup c, Monad m) => c -> ChronicleT c m a
 disclose c = dictate c >> return def
 
 -- | @'confess' c@ is an action that ends with a final output @c@.
 --   
 --   Equivalent to 'throwError' for the 'Error' monad.
-confess :: (Monoid c, Monad m) => c -> ChronicleT c m a
+confess :: (Semigroup c, Monad m) => c -> ChronicleT c m a
 confess c = ChronicleT $ return (This c)
 
 -- | @'memento' m@ is an action that executes the action @m@, returning either
@@ -169,7 +170,7 @@ confess c = ChronicleT $ return (This c)
 --   Similar to 'catchError' in the 'Error' monad, but with a notion of 
 --   non-fatal errors (which are accumulated) vs. fatal errors (which are caught
 --   without accumulating).
-memento :: (Monoid c, Monad m) => ChronicleT c m a -> ChronicleT c m (Either c a)
+memento :: (Semigroup c, Monad m) => ChronicleT c m a -> ChronicleT c m (Either c a)
 memento m = ChronicleT $ 
     do cx <- runChronicleT m
        return $ case cx of
@@ -180,7 +181,7 @@ memento m = ChronicleT $
 -- | @'absolve' x m@ is an action that executes the action @m@ and discards any
 --   record it had. The default value @x@ will be used if @m@ ended via 
 --   'confess'.
-absolve :: (Monoid c, Monad m) => a -> ChronicleT c m a -> ChronicleT c m a
+absolve :: (Semigroup c, Monad m) => a -> ChronicleT c m a -> ChronicleT c m a
 absolve x m = ChronicleT $ 
     do cy <- runChronicleT m
        return $ case cy of
@@ -194,7 +195,7 @@ absolve x m = ChronicleT $
 --   and only the record kept.
 --
 --   This can be seen as converting non-fatal errors into fatal ones.
-condemn :: (Monoid c, Monad m) => ChronicleT c m a -> ChronicleT c m a
+condemn :: (Semigroup c, Monad m) => ChronicleT c m a -> ChronicleT c m a
 condemn (ChronicleT m) = ChronicleT $ do 
     m' <- m
     return $ case m' of
@@ -207,6 +208,6 @@ condemn (ChronicleT m) = ChronicleT $ do
 --   function @f@ to its output, leaving the return value unchanged.
 --   
 --   Equivalent to 'censor' for the 'Writer' monad.
-retcon :: (Monoid c, Monad m) => (c -> c) -> ChronicleT c m a -> ChronicleT c m a
+retcon :: (Semigroup c, Monad m) => (c -> c) -> ChronicleT c m a -> ChronicleT c m a
 retcon f m = ChronicleT $ mapThis f `liftM` runChronicleT m
 

--- a/Control/Monad/Trans/Chronicle.hs
+++ b/Control/Monad/Trans/Chronicle.hs
@@ -30,7 +30,6 @@ import Data.Default.Class
 import Data.Functor.Apply (Apply(..))
 import Data.Functor.Bind (Bind(..))
 import Data.Functor.Identity
-import Data.Monoid hiding ((<>))
 import Data.Semigroup
 
 import Control.Monad.Error.Class

--- a/Data/These.hs
+++ b/Data/These.hs
@@ -245,28 +245,28 @@ instance Bitraversable1 These where
     bitraverse1 _ g (That x) = That <$> g x
     bitraverse1 f g (These x y) = These <$> f x <.> g y
 
-instance (Monoid a) => Apply (These a) where
+instance (Semigroup a) => Apply (These a) where
     This  a   <.> _         = This a
     That    _ <.> This  b   = This b
     That    f <.> That    x = That (f x)
     That    f <.> These b x = These b (f x)
-    These a _ <.> This  b   = This (mappend a b)
+    These a _ <.> This  b   = This (a <> b)
     These a f <.> That    x = These a (f x)
-    These a f <.> These b x = These (mappend a b) (f x)
+    These a f <.> These b x = These (a <> b) (f x)
 
-instance (Monoid a) => Applicative (These a) where
+instance (Semigroup a) => Applicative (These a) where
     pure = That
     (<*>) = (<.>)
 
-instance (Monoid a) => Bind (These a) where
+instance (Semigroup a) => Bind (These a) where
     This  a   >>- _ = This a
     That    x >>- k = k x
     These a x >>- k = case k x of
-                          This  b   -> This  (mappend a b)
+                          This  b   -> This  (a <> b)
                           That    y -> These a y
-                          These b y -> These (mappend a b) y
+                          These b y -> These (a <> b) y
 
-instance (Monoid a) => Monad (These a) where
+instance (Semigroup a) => Monad (These a) where
     return = pure
     (>>=) = (>>-)
 


### PR DESCRIPTION
I noticed that the Applicative/Monad instances of These and Chronicle only require a Semigroup cosntraint on the 'c' ... just a quick PR in case you wanted to consider generalizing the constraints so that they can be used with 'c''s that are Semigroups but not Monoids and gain some extra usefulness :)

Note that the Alternative and MonadPlus instances for ChronicleT require 'mempty', so needs Monoid.  But because Semigroup is not yet a superclass for Monoid, they would require both constraints.