### PR TITLE
Add foldMapCrosswalk

### DIFF
--- a/Data/Align.hs
+++ b/Data/Align.hs
@@ -18,6 +18,7 @@ module Data.Align (
 
                   -- * Crosswalk
                   , Crosswalk(..)
+                  , foldMapCrosswalk
 
                   -- * Bicrosswalk
                   , Bicrosswalk(..)
@@ -125,6 +126,9 @@ class (Functor f) => Align f where
 
   #-}
 
+instance Monoid a => Align (Const a) where
+    nil = Const mempty
+    align (Const a) (Const b) = Const (a `mappend` b)
 
 instance Align Maybe where
     nil = Nothing
@@ -338,6 +342,10 @@ class (Functor t, Foldable t) => Crosswalk t where
 #if __GLASGOW_HASKELL__ >= 707
     {-# MINIMAL crosswalk | sequenceL #-}
 #endif
+
+-- | Implementation of 'foldMap' using 'Crosswalk'.
+foldMapCrosswalk :: (Crosswalk t, Monoid m) => (a -> m) -> t a -> m
+foldMapCrosswalk f = getConst . crosswalk (Const . f)
 
 instance Crosswalk Identity where
     crosswalk f (Identity a) = fmap Identity (f a)

--- a/test/Tests.hs
+++ b/test/Tests.hs
@@ -48,6 +48,7 @@ theseProps :: TestTree
 theseProps = testGroup "These"
   [ functorProps
   , traversableProps
+  , dataAlignLaws "Const" (Proxy :: Proxy (Const (Sum Int)))
   , dataAlignLaws "[]" (Proxy :: Proxy [])
   , dataAlignLaws "HashMap String" (Proxy :: Proxy (HashMap String))
   , dataAlignLaws "IntMap" (Proxy :: Proxy IntMap)
@@ -189,6 +190,7 @@ crosswalkLaws
 crosswalkLaws name _ = testGroup ("Data.CrossWalk laws: " <> name)
   [ QC.testProperty "crosswalk (const nil) = const nil" firstLaw
   , QC.testProperty "crosswalk f = sequenceL . fmap f" secondLaw
+  , QC.testProperty "foldMap = foldMapCrosswalk" foldMapProp
   ]
   where
     -- f = Map Index
@@ -204,6 +206,12 @@ crosswalkLaws name _ = testGroup ("Data.CrossWalk laws: " <> name)
       where
         lhs = crosswalk f x
         rhs = sequenceL . fmap f $ x
+
+    foldMapProp :: Fun Int [Int] -> t Int -> Property
+    foldMapProp (Fun _ f) xs = lhs === rhs
+      where
+        lhs = foldMap f xs
+        rhs = foldMapCrosswalk f xs
 
 -------------------------------------------------------------------------------
 -- aeson


### PR DESCRIPTION
`Const` isn't lawful  `Align` as `join align = fmap (join These)` law doesn't hold.

Yet, `foldMap = foldMapCrosswalk` seems to work.

I forgot the join-law motivation.