### PR TITLE
WIP: Add functions to diff/patch Filterable Semialigns.

### DIFF
--- a/semialign-indexed/CHANGELOG.md
+++ b/semialign-indexed/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Add `Data.Semialign.Indexed.diff`.
+* Add `Data.Semialign.Indexed.diffNoEq`.
+
 # 1
 
 Split out of `these` package.

--- a/semialign-indexed/semialign-indexed.cabal
+++ b/semialign-indexed/semialign-indexed.cabal
@@ -1,5 +1,5 @@
 cabal-version:      >=1.10
-name:               semialign-indexed 
+name:               semialign-indexed
 version:            1
 synopsis:           SemialignWithIndex, i.e. izipWith and ialignWith
 homepage:           https://github.com/isomorphism/these
@@ -53,6 +53,7 @@ library
     , lens                  >=4.17     && <4.18
     , unordered-containers  >=0.2.8.0  && <0.3
     , vector                >=0.12.0.2 && <0.13
+    , witherable            >=0.2      && <0.4
 
   -- base shims
   if !impl(ghc >=8.0)

--- a/semialign/CHANGELOG.md
+++ b/semialign/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+* Add `Data.Semialign.diff`.
+* Add `Data.Semialign.diffNoEq`.
+* Add `Data.Semialign.patch`.
+
 # 1
 
 Split out of `these` package.

--- a/semialign/semialign.cabal
+++ b/semialign/semialign.cabal
@@ -64,6 +64,7 @@ library
     , tagged                >=0.8.6    && <0.9
     , unordered-containers  >=0.2.8.0  && <0.3
     , vector                >=0.12.0.2 && <0.13
+    , witherable            >=0.2      && <0.4
 
   -- base shims
   if !impl(ghc >=8.2)

--- a/semialign/src/Data/Semialign.hs
+++ b/semialign/src/Data/Semialign.hs
@@ -12,6 +12,8 @@ module Data.Semialign (
     lpadZip, lpadZipWith,
     rpadZip, rpadZipWith,
     alignVectorWith,
+    -- * Diffing/patching
+    diff, diffNoEq, patch
     ) where
 
 import Data.Semialign.Internal


### PR DESCRIPTION
Closes #115.

This PR adds a `witherable` direct dependency to `semialign`, and an indirect dependency on `base-orphans`.

I'm happy with `Data.Semialign.diff`, `Data.Semialign.diffNoEq` and `Data.Semialign.patch`. I'm merely content with `Data.Semialign.Indexed.idiff` and `Data.Semialign.Indexed.idiffNoEq`, because I can't write a good `ipatch`:

* The closest I came was a type like `ipatch :: (FunctorWithIndex i f, Filterable f) => (i -> Maybe (Maybe a)) -> f a -> f a`. That patch function returns `Nothing` for "no change", `Just Nothing` to delete, and `Just (Just a)` to replace `a`. This feels a bit awkward. Constructing that patch function from the result of `idiff` isn't quite as nice as it was for `Data.Semialign.{diff/patch}`. This makes the properties harder to write.
* If the patching function would return `Just x` for some input `i` that isn't generated by `imap` over the input structure, we never notice that we wanted to add, not just update.
* We are forced to `imap` and then `catMaybes`, which walks the structure twice, because;
* There is no `imapMaybe` because we don't have a `FilterableWithIndex` typeclass. I can't add that typeclass to `witherable` without incurring a dependency on `lens` over there. (`FunctorWithIndex` won't ever escape `lens` either, see https://github.com/ekmett/lens/issues/258 .)

There may be some connection with `Representable`, but I don't know because my CT power level is under 9000.

Doctests all work, but I haven't set up `doctest` infrastructure in the packages themselves, in case that's not something you want to maintain.

Changelog entries are under an "unreleased" heading.