### PR TITLE
Move `zip` and `zipWith` from `Semialign` to a new class `Semizip`

### DIFF
--- a/semialign/src/Data/Semialign.hs
+++ b/semialign/src/Data/Semialign.hs
@@ -4,6 +4,7 @@ module Data.Semialign (
     Semialign (..),
     Align (..),
     Unalign (..),
+    Semizip (..),
     Zip (..),
     Unzip (..),
     unzipDefault,

--- a/semialign/src/Data/Semialign/Internal.hs
+++ b/semialign/src/Data/Semialign/Internal.hs
@@ -243,7 +243,7 @@ class Semialign f => Unalign f where
 -- @
 --
 class Semialign f => Zip f where
-    -- | A /full/ strucutre.
+    -- | A /full/ structure.
     full :: a -> f a
 
 -- | Right inverse of 'zip'.

--- a/semialign/src/Data/Zip.hs
+++ b/semialign/src/Data/Zip.hs
@@ -5,6 +5,7 @@
 --
 module Data.Zip (
     Semialign (..),
+    Semizip (..),
     Zip (..),
     Unzip (..),
     unzipDefault,
@@ -29,7 +30,7 @@ import Data.Functor.Apply (Apply (..))
 newtype Zippy f a = Zippy { getZippy :: f a }
   deriving (Eq, Ord, Show, Read, Functor)
 
-instance (Semialign f, Semigroup a) => Semigroup (Zippy f a) where
+instance (Zip f, Semigroup a) => Semigroup (Zippy f a) where
     Zippy x <> Zippy y = Zippy $ zipWith (<>) x y
 
 instance (Zip f, Monoid a) => Monoid (Zippy f a) where
@@ -37,7 +38,7 @@ instance (Zip f, Monoid a) => Monoid (Zippy f a) where
     mappend (Zippy x) (Zippy y) = Zippy $ zipWith mappend x y
 
 #ifdef MIN_VERSION_semigroupoids
-instance Semialign f => Apply (Zippy f) where
+instance Zip f => Apply (Zippy f) where
     Zippy f <.> Zippy x = Zippy $ zipWith ($) f x
 #endif
 

--- a/these-tests/test/Tests/AlignWrong.hs
+++ b/these-tests/test/Tests/AlignWrong.hs
@@ -32,6 +32,7 @@ instance Ord k => Semialign (WrongMap k) where
        | Map.null x = WM $ That <$> y
        | otherwise  = WM $ Map.intersectionWith These x y
 
+instance Ord k => Semizip (WrongMap k) where
     zip (WM x) (WM y) = WM (Map.intersectionWith (,) x y)
 
 -------------------------------------------------------------------------------
@@ -61,6 +62,7 @@ instance Ord k => Semialign (WeirdMap k) where
         g (That (k, a))         = (k, f (That a))
         g (These (k, a) (_, b)) = (k, f (These a b))
 
+instance Ord k => Semizip (WeirdMap k) where
     zipWith f (WeirdMap x) (WeirdMap y) = WeirdMap $ Map.fromList $
         zipWith (\(k, a) (_, b) -> (k, f a b)) (Map.toList x) (Map.toList y)
 
@@ -96,6 +98,7 @@ instance Semialign R where
       where
         shape = fmap (() <$)
 
+instance Semizip R where
     -- doesn't work with align above
     zip (Nest ass) (Nest bss) = Nest $ zipWith (zipWith (,)) ass bss
 

--- a/these-tests/test/Tests/Semialign.hs
+++ b/these-tests/test/Tests/Semialign.hs
@@ -127,7 +127,7 @@ semialignLaws p = testGroup name $ case p of
 {-# NOINLINE unalignLaws' #-}
 
 semialignLaws'
-    :: forall f proxy. (Semialign f, Foldable f
+    :: forall f proxy. (Semizip f, Foldable f
        , Eq (f A), Show (f A), Arbitrary (f A)
        , Eq (f B), Show (f B), Arbitrary (f B)
        , Eq (f C), Show (f C), Arbitrary (f C)

--- a/these-tests/test/Tests/SemialignWithIndex.hs
+++ b/these-tests/test/Tests/SemialignWithIndex.hs
@@ -67,7 +67,7 @@ alignWithKeyProps = testGroup "AlignWithIndex"
 data P (f :: * -> *) = P
 
 semialignIndexedLaws
-    :: forall f i. (SemialignWithIndex i f, Typeable1 f
+    :: forall f i. (SemizipWithIndex i f, Typeable1 f
        , Function i, CoArbitrary i, Show i
        , Eq (f A), Show (f A), Arbitrary (f A)
        , Eq (f B), Show (f B), Arbitrary (f B)


### PR DESCRIPTION
There exist datastructures for which `align` makes sense but `zip` does not.  This PR separates `zip` and `zipWith` out from `Semialign` and moves them into a new subclass, `Semizip`.  `Semizip` becomes a superclass of the existing `Zip` class.